### PR TITLE
Add CDL-B channel generation and validation scripts

### DIFF
--- a/check_cdlb_channel.py
+++ b/check_cdlb_channel.py
@@ -1,0 +1,92 @@
+import numpy as np
+import tensorflow as tf
+from sionna.phy.channel.tr38901 import CDL, PanelArray
+from gen_cdlb_channel import generate_cdl_b_channel
+
+# Reference values from 3GPP TR 38.901 for CDL-B
+CDL_POWERS_B_DB = np.array([
+    0.0, -2.2, -4.0, -3.2, -9.8, -1.2, -3.4, -5.2, -7.6, -3.0,
+    -8.9, -9.0, -4.8, -5.7, -7.5, -1.9, -7.6, -12.2, -9.8, -11.4,
+    -14.9, -9.2, -11.3
+])
+
+CDL_DELAYS_B = np.array([
+    0.0, 0.1072, 0.2155, 0.2095, 0.2870, 0.2986, 0.3752, 0.5055,
+    0.3681, 0.3697, 0.5700, 0.5283, 1.1021, 1.2756, 1.5474, 1.7842,
+    2.0169, 2.8294, 3.0219, 3.6187, 4.1067, 4.2790, 4.7834
+])
+
+DELAY_SPREAD = 100e-9  # s
+CARRIER_FREQUENCY = 3.5e9  # Hz
+
+MAX_ERR_REL = 3e-2
+MAX_ERR_ABS = 1e-4
+
+
+def check_cdlb_compliance(batch_size=10000):
+    """Return True if CDL-B statistics match 3GPP reference."""
+    tx = PanelArray(
+        num_rows_per_panel=1,
+        num_cols_per_panel=1,
+        polarization="single",
+        polarization_type="V",
+        antenna_pattern="omni",
+        carrier_frequency=CARRIER_FREQUENCY,
+        precision="double",
+    )
+    rx = PanelArray(
+        num_rows_per_panel=1,
+        num_cols_per_panel=1,
+        polarization="single",
+        polarization_type="V",
+        antenna_pattern="omni",
+        carrier_frequency=CARRIER_FREQUENCY,
+        precision="double",
+    )
+
+    cdl = CDL(
+        "B",
+        delay_spread=DELAY_SPREAD,
+        carrier_frequency=CARRIER_FREQUENCY,
+        ut_array=rx,
+        bs_array=tx,
+        direction="downlink",
+        precision="double",
+    )
+    a, tau = cdl(batch_size, 1, 100e6)
+    a = a[:, 0, 0, 0, 0, :, 0].numpy()
+    tau = tau.numpy()[0, 0, 0]
+
+    p = np.mean(np.abs(a) ** 2, axis=0)
+    ref_p = 10 ** (CDL_POWERS_B_DB / 10.0)
+    ref_p = ref_p / np.sum(ref_p)
+    order = np.argsort(CDL_DELAYS_B)
+    ref_p = ref_p[order]
+
+    delays = tau / DELAY_SPREAD
+    ref_delays = np.sort(CDL_DELAYS_B)
+
+    max_err_p = np.max(np.abs(ref_p - p) / ref_p)
+    max_err_tau = np.max(np.abs(ref_delays - delays))
+
+    return max_err_p <= MAX_ERR_REL and max_err_tau <= MAX_ERR_ABS, max_err_p, max_err_tau
+
+
+def main():
+    h = generate_cdl_b_channel(num_ues=4)
+    print("Channel shape:", h.shape)
+    avg_power = tf.reduce_mean(tf.abs(h) ** 2).numpy()
+    print(f"Average normalized power: {avg_power:.4f}")
+
+    ok, err_p, err_tau = check_cdlb_compliance()
+    print(f"Max relative power error: {err_p:.2e}")
+    print(f"Max absolute delay error: {err_tau:.2e}")
+    if ok and np.isclose(avg_power, 1.0, rtol=1e-2):
+        print("CDL-B channel complies with 3GPP reference within tolerance.")
+    else:
+        print("CDL-B channel does NOT meet 3GPP reference.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/explain_check_cdlb_channel.py
+++ b/explain_check_cdlb_channel.py
@@ -1,0 +1,30 @@
+"""
+说明程序: 解释 `check_cdlb_channel.py` 的工作流程以及验证依据。
+
+该脚本调用 `check_cdlb_compliance` 并逐步说明验证逻辑:
+
+1. 从 3GPP TR 38.901 读取 CDL-B 的相对路径功率与时延表。
+2. 构造单天线、单极化的 `PanelArray` 并使用 `CDL` 类生成大量 CDL-B 信道抽样。
+3. 统计每条路径的平均功率与时延, 与参考表进行比较。
+4. 若功率相对误差小于 3% 且时延误差小于 1e-4 秒, 则认为实现符合标准。
+
+由于 CDL 模型是随机过程, 其统计量在大样本下应收敛到标准提供的均值, 
+因此通过统计检验可以判断实现是否遵循 3GPP 定义。
+"""
+
+from check_cdlb_channel import check_cdlb_compliance
+
+
+def main():
+    ok, err_p, err_tau = check_cdlb_compliance()
+    print("check_cdlb_channel.py 通过比较统计功率和时延与标准值的误差来验证 CDL-B 模型实现。")
+    print(f"最大相对功率误差: {err_p:.2e}")
+    print(f"最大绝对时延误差: {err_tau:.2e}")
+    if ok:
+        print("误差均在容差范围内, 说明生成的 CDL-B 信道符合 3GPP 参考模型。")
+    else:
+        print("误差超出容差, CDL-B 信道可能不符合 3GPP 模型。")
+
+
+if __name__ == "__main__":
+    main()

--- a/gen_cdlb.md
+++ b/gen_cdlb.md
@@ -1,0 +1,29 @@
+# Plan to generate CDL-B channel matrix
+
+1. **Define antenna arrays**
+   - Create a `PanelArray` for the base station (BS) with 64 transmit antennas using 8×4 dual-polarized (cross) elements.
+   - Create a `PanelArray` for the user terminals (UEs) with 4 receive antennas using 2×1 dual-polarized (cross) elements.
+
+2. **Configure resource grid**
+   - Instantiate a `ResourceGrid` with one OFDM symbol, FFT size 768, and desired subcarrier spacing (e.g., 15 kHz).
+
+3. **Instantiate CDL-B channel model**
+   - Use Sionna's `CDL` class with model "B", setting parameters such as delay spread, carrier frequency, arrays, and downlink direction.
+
+4. **Generate frequency-domain channel**
+   - Use `GenerateOFDMChannel` with the CDL-B model and resource grid.
+   - Sample the channel with a batch size equal to the number of UEs (4).
+
+5. **Reshape to desired format**
+   - Squeeze singleton dimensions and transpose to obtain a tensor of shape `(4, 64, 768, 4)` corresponding to `(rx_ant, tx_ant, subcarrier, UE)`.
+
+6. **Store or process the result**
+   - Optionally save the complex tensor to a `.npy` file for later use.
+
+7. **Verify**
+   - Run the script to confirm the generated tensor has the expected shape and properties.
+
+8. **Add compliance check**
+   - Implement `check_cdlb_channel.py` to statistically compare tap powers and delays against 3GPP CDL-B reference values.
+   - Report the maximum deviation and flag if tolerances are exceeded.
+

--- a/gen_cdlb_channel.py
+++ b/gen_cdlb_channel.py
@@ -1,0 +1,59 @@
+import tensorflow as tf
+import numpy as np
+from sionna.phy.channel.tr38901 import CDL, PanelArray
+from sionna.phy.channel import GenerateOFDMChannel
+from sionna.phy.ofdm import ResourceGrid
+
+
+def generate_cdl_b_channel(num_ues=4):
+    """Generate a CDL-B channel matrix with shape (4, 64, 768, num_ues).
+
+    Returns a TensorFlow tensor of complex64 values corresponding to
+    (rx_ant, tx_ant, subcarrier, UE).
+    """
+    carrier_freq = 3.5e9
+
+    bs_array = PanelArray(
+        num_rows_per_panel=8,
+        num_cols_per_panel=4,
+        polarization="dual",
+        polarization_type="cross",
+        antenna_pattern="omni",
+        carrier_frequency=carrier_freq,
+    )
+
+    ut_array = PanelArray(
+        num_rows_per_panel=2,
+        num_cols_per_panel=1,
+        polarization="dual",
+        polarization_type="cross",
+        antenna_pattern="omni",
+        carrier_frequency=carrier_freq,
+    )
+
+    rg = ResourceGrid(
+        num_ofdm_symbols=1,
+        fft_size=768,
+        subcarrier_spacing=15e3,
+    )
+
+    cdl = CDL(
+        "B",
+        delay_spread=100e-9,
+        carrier_frequency=carrier_freq,
+        ut_array=ut_array,
+        bs_array=bs_array,
+        direction="downlink",
+    )
+
+    ofdm_channel = GenerateOFDMChannel(cdl, rg, normalize_channel=True)
+    h_freq = ofdm_channel(batch_size=num_ues)
+    h_freq = tf.squeeze(h_freq, axis=[1, 3, 5])  # [UE, rx_ant, tx_ant, subcarrier]
+    h_freq = tf.transpose(h_freq, perm=[1, 2, 3, 0])  # (rx_ant, tx_ant, subcarrier, UE)
+    return h_freq
+
+
+if __name__ == "__main__":
+    h = generate_cdl_b_channel(num_ues=4)
+    print("Channel shape:", h.shape)
+    np.save("cdl_b_channel.npy", h.numpy())


### PR DESCRIPTION
## Summary
- document compliance-check step in CDL-B channel plan
- add `check_cdlb_channel.py` to validate tap powers and delays against 3GPP references
- add `explain_check_cdlb_channel.py` to illustrate the checker workflow

## Testing
- `PYTHONPATH=src python gen_cdlb_channel.py`
- `PYTHONPATH=src python explain_check_cdlb_channel.py`
- `PYTHONPATH=src python check_cdlb_channel.py`


------
https://chatgpt.com/codex/tasks/task_e_68be75327744832a8b7e5792622e854f